### PR TITLE
checks: check also files with extension

### DIFF
--- a/checks/checks.py
+++ b/checks/checks.py
@@ -295,6 +295,11 @@ LICENSE_FILES = [
     'COPYING',
 ]
 
+LICENSE_FILES_EXTENSIONS = [
+    '',
+    '.TXT',
+]
+
 
 def third_party_checks(pname):
     """Check a directory containing third party contents.
@@ -315,9 +320,12 @@ def third_party_checks(pname):
 
         license_files = []
         for lname in LICENSE_FILES:
-            lpath = dpath / lname
-            if lpath.exists():
-                license_files.append(lpath)
+            for lext in LICENSE_FILES_EXTENSIONS:
+                lname_ext = lname + lext
+                lpath = dpath / lname_ext
+
+                if lpath.exists():
+                    license_files.append(lpath)
 
         if not license_files:
             reldpath = relpath(dpath)


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

The third_party license files might have some extensions. This PR adds another list to parse with all the possible extensions for the LICENSE files (e.g. when using [RapidWright as third_party](https://github.com/Xilinx/RapidWright/blob/master/LICENSE.TXT)).

A more flexible solution might be to be able to pass these lists when invoking the action.