### PR TITLE
Fix hashbang check in shell scripts

### DIFF
--- a/checks/checks.py
+++ b/checks/checks.py
@@ -127,9 +127,9 @@ def shell_check_shebang(filename, header_lines):
     while len(header_lines) < 1:
         header_lines.append('')
 
-    shebang_lines = ['#!/bin/bash\n', '#! /bin/bash\n', '#!/usr/bin/env bash\n', '#! /usr/bin/env bash\n']
+    shebang_lines = ['#!/bin/bash', '#! /bin/bash', '#!/usr/bin/env bash', '#! /usr/bin/env bash']
     for shebang_line in shebang_lines:
-        if header_lines[0] == shebang_line:
+        if header_lines[0].startswith(shebang_line):
             return []
 
     return report_file_error(


### PR DESCRIPTION
In other test I spotted error in checking correct hashbang:
```
#!/bin/bash -xe\n
```
https://github.com/antmicro/prjuray/runs/2784035151?check_suite_focus=true#step:4:243

This fix should solve this issue.