### PR TITLE
update_conda_lock: Fix pip dependency flattening

### DIFF
--- a/update_conda_lock/update_lock.py
+++ b/update_conda_lock/update_lock.py
@@ -328,7 +328,7 @@ def lock_pip_dependencies(
             'w', delete=False)
     tmp_requirements_path = tmp_requirements_file.name
     try:
-        tmp_requirements_file.write('\n'.join(pip_deps))
+        tmp_requirements_file.write('\n'.join(all_pip_deps))
         tmp_requirements_file.close()
 
         # Paths in `requirements.txt` are relative to the `root_dir`


### PR DESCRIPTION
After the last reformatting in PR the script still worked well unless
the `pip` key in `environment.yml` contained `-r <FILE>`.

Signed-off-by: Adam Jeliński <ajelinski@antmicro.com>