### PR TITLE
Allow license specific suffixes

### DIFF
--- a/checks/checks.py
+++ b/checks/checks.py
@@ -342,6 +342,8 @@ LICENSE_FILES_EXTENSIONS = [
     '',
     '.TXT',
     '.MD',
+    '-APACHE',
+    '-MIT',
 ]
 
 


### PR DESCRIPTION
This is needed to make: https://github.com/fabianschuiki/moore/ work with sv-tests.